### PR TITLE
Default to showing all files.

### DIFF
--- a/ls.c
+++ b/ls.c
@@ -63,11 +63,12 @@ char **argv;		/* argument vector */
   int size_sw, attr_sw;
   int sort_sw, case_sw;
   int blm;
+  int args_left;
 
   size_sw = attr_sw = sort_sw = case_sw = 0;
-  get_args(&size_sw, &attr_sw, &sort_sw, &case_sw, argc, argv);
+  args_left = get_args(&size_sw, &attr_sw, &sort_sw, &case_sw, argc, argv);
   get_params();
-  if ((count = save_fcb(fcb_ptr,attr_sw,&tot)) == -1){
+  if ((count = save_fcb(fcb_ptr,attr_sw,&tot,args_left)) == -1){
     printf("Warning: FCB list too large for available memory\n");
     exit();
     }
@@ -86,15 +87,23 @@ char **argv;		/* argument vector */
     }
 }
 
-save_fcb(fcb_ptr, attr, ncnt)
+save_fcb(fcb_ptr, attr, ncnt, arg_present)
 char *fcb_ptr[];
 char *ncnt;
 int attr;
+int arg_present;
 {
   int nsave,n;
   char *p, *malloc(), *buf_ptr;
   char ro, sys;
   char cusr, fusr;
+
+  /* If nothing was specified then we need to add a default pattern of
+   * '????????.???'. */
+  if ( arg_present == 0 ) {
+      for( n = 0; n < 11; n++ )
+          FCBADR[1 + n] = '?';
+  }
 
   cusr = usr;
   *ncnt = nsave = 0;
@@ -256,6 +265,10 @@ char *argv[];
         default:
 	  printf("Warning: Illegal switch (%c) - Ignored\n",*sptr);
         }
+    else
+        return 1;
+
+   return 0;
 }
 
 sort_fcb(v, n, num)


### PR DESCRIPTION
This pull-request changes the default behaviour to show all files,
for example:

```
C>ls
Directory for Disk C:  User  0:
as       com | cc       com | cc       msg | c        lib | ctype    h
errno    h   | fcntl    h   | io       h   | libc     h   | ln       com
math     h   | m        lib | rom      lib | setjmp   h   | sgtty    h
stdio    h   | t        lib | compat   c   | compat   h   | config   h
funcs    c   | funcs    h   | kcalc    c   | kcalc    sub | makefile
readme   md  | term     c   | term     h   | tinyexpr c   | tinyexpr h
todo         | compat   asm | echo     c   | funcs    asm | hello    c
term     asm | tinyexpr asm | compat   o   | funcs    o   | kcalc    o
term     o   | tinyexpr o   | kcalc    com | kcalc    asm | te       bkp
ls       c   | ls       asm | ls       o   | ls       com

Listed 49/21041 files   3447/3744 Blocks used   468K Disk space used
```

We do this by defaulting to the pattern `????????.???` if no arguments
are present (except for the option-parameters).

This means we can honor flags by default too:

```
C>ls *.c
Directory for Disk C:  User  0:
compat   c   | funcs    c   | kcalc    c   | term     c   | tinyexpr c
echo     c   | hello    c   | ls       c

Listed 8/21000 files   402/480 Blocks used   60K Disk space used

C>ls *.c -u
Directory for Disk C:  User  0:
compat   c   | funcs    c   | kcalc    c   | term     c   | tinyexpr c
echo     c   | hello    c   | ls       c

Listed 8/21000 files   402/480 Blocks used   60K Disk space used

C>ls -u
Directory for Disk C:  User  0:
AS       COM | CC       COM | CC       MSG | C        LIB | CTYPE    H
ERRNO    H   | FCNTL    H   | IO       H   | LIBC     H   | LN       COM
MATH     H   | M        LIB | ROM      LIB | SETJMP   H   | SGTTY    H
STDIO    H   | T        LIB | COMPAT   C   | COMPAT   H   | CONFIG   H
FUNCS    C   | FUNCS    H   | KCALC    C   | KCALC    SUB | MAKEFILE
README   MD  | TERM     C   | TERM     H   | TINYEXPR C   | TINYEXPR H
TODO         | COMPAT   ASM | ECHO     C   | FUNCS    ASM | HELLO    C
TERM     ASM | TINYEXPR ASM | COMPAT   O   | FUNCS    O   | KCALC    O
TERM     O   | TINYEXPR O   | KCALC    COM | KCALC    ASM | TE       BKP
LS       C   | LS       ASM | LS       O   | LS       COM

Listed 49/21041 files   3447/3744 Blocks used   468K Disk space used

C>
```